### PR TITLE
fix defect for admin ssh key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,8 +180,8 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "virtual_machine_scale
             for_each = linux_configuration.value.admin_ssh_key_id == null ? [] : linux_configuration.value.admin_ssh_key_id
 
             content {
-              public_key = var.admin_ssh_keys[each.key].public_key
-              username   = var.admin_ssh_keys[each.key].username
+              public_key = var.admin_ssh_keys[admin_ssh_key.value].public_key
+              username   = var.admin_ssh_keys[admin_ssh_key.value].username
             }
           }
           dynamic "secret" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ EOT
 }
 
 variable "admin_ssh_keys" {
-  type = set(object({
+  type = map(object({
     id         = string
     public_key = string
     username   = string


### PR DESCRIPTION
#93  [AVM Module Issue]

## Description


Change 1:
Error:
![image](https://github.com/user-attachments/assets/61c12c77-789b-4fdc-85e0-9fc5db5f8f44)
 
Fix:
UPDATE each.key to admin_ssh_key.key--> in dynamic block have to unwrap with the dynamic block name.

Change 2:
Error:
![image](https://github.com/user-attachments/assets/b7f24ab6-3daa-436e-abda-5e4bba2ad103)

Fix:
Use admin_ssh_key.value instead of admin_ssh_key.key because admin_ssh_key_id is a set therefore the key is not meaningful to index the admin_ssh_keys

Change 3:
Update admin_ssh_keys variable from set to map in order to index the map



## Questions

What is the rationale for using admin_ssh_key_id and is this really required in the code to be defined in order to activate the dynamic admin_ssh_key block?
