### PR TITLE
bump: add AzureRM version 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~>1.15)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.15, < 3.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 

--- a/examples/autoscale-linux/README.md
+++ b/examples/autoscale-linux/README.md
@@ -22,7 +22,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 
@@ -210,7 +210,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)
 
@@ -302,7 +302,7 @@ Version: 0.4.1
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: =0.1.0
+Version: 0.3.0
 
 ### <a name="module_terraform_azurerm_avm_res_compute_virtualmachinescaleset"></a> [terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset](#module\_terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset)
 

--- a/examples/autoscale-linux/main.tf
+++ b/examples/autoscale-linux/main.tf
@@ -6,7 +6,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 

--- a/examples/autoscale-linux/terraform.tf
+++ b/examples/autoscale-linux/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/autoscale-windows/README.md
+++ b/examples/autoscale-windows/README.md
@@ -21,7 +21,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 
@@ -219,7 +219,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)
 
@@ -308,7 +308,7 @@ Version: 0.4.1
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: =0.1.0
+Version: 0.3.0
 
 ### <a name="module_terraform_azurerm_avm_res_compute_virtualmachinescaleset"></a> [terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset](#module\_terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset)
 

--- a/examples/autoscale-windows/main.tf
+++ b/examples/autoscale-windows/main.tf
@@ -6,7 +6,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 

--- a/examples/autoscale-windows/terraform.tf
+++ b/examples/autoscale-windows/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/default-linux/README.md
+++ b/examples/default-linux/README.md
@@ -22,7 +22,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 
@@ -215,7 +215,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)
 
@@ -306,7 +306,7 @@ Version: 0.4.1
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: =0.1.0
+Version: 0.3.0
 
 ### <a name="module_terraform_azurerm_avm_res_compute_virtualmachinescaleset"></a> [terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset](#module\_terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset)
 

--- a/examples/default-linux/main.tf
+++ b/examples/default-linux/main.tf
@@ -6,7 +6,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 

--- a/examples/default-linux/terraform.tf
+++ b/examples/default-linux/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/default-windows/README.md
+++ b/examples/default-windows/README.md
@@ -21,7 +21,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 
@@ -219,7 +219,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)
 
@@ -307,7 +307,7 @@ Version: 0.4.1
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: =0.1.0
+Version: 0.3.0
 
 ### <a name="module_terraform_azurerm_avm_res_compute_virtualmachinescaleset"></a> [terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset](#module\_terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset)
 

--- a/examples/default-windows/main.tf
+++ b/examples/default-windows/main.tf
@@ -6,7 +6,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 

--- a/examples/default-windows/terraform.tf
+++ b/examples/default-windows/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/rbac-and-mi-linux/README.md
+++ b/examples/rbac-and-mi-linux/README.md
@@ -21,7 +21,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 
@@ -226,7 +226,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)
 
@@ -319,7 +319,7 @@ Version: 0.4.1
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: =0.1.0
+Version: 0.3.0
 
 ### <a name="module_terraform_azurerm_avm_res_compute_virtualmachinescaleset"></a> [terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset](#module\_terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset)
 

--- a/examples/rbac-and-mi-linux/main.tf
+++ b/examples/rbac-and-mi-linux/main.tf
@@ -6,7 +6,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 

--- a/examples/rbac-and-mi-linux/terraform.tf
+++ b/examples/rbac-and-mi-linux/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/rbac-and-mi-windows/README.md
+++ b/examples/rbac-and-mi-windows/README.md
@@ -21,7 +21,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 
@@ -229,7 +229,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)
 
@@ -319,7 +319,7 @@ Version: 0.4.1
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: =0.1.0
+Version: 0.3.0
 
 ### <a name="module_terraform_azurerm_avm_res_compute_virtualmachinescaleset"></a> [terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset](#module\_terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset)
 

--- a/examples/rbac-and-mi-windows/main.tf
+++ b/examples/rbac-and-mi-windows/main.tf
@@ -6,7 +6,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 

--- a/examples/rbac-and-mi-windows/terraform.tf
+++ b/examples/rbac-and-mi-windows/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/upgrade-policy-linux/README.md
+++ b/examples/upgrade-policy-linux/README.md
@@ -23,7 +23,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 
@@ -221,7 +221,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~>1.15)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)
 
@@ -312,7 +312,7 @@ Version: 0.4.1
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: =0.1.0
+Version: 0.3.0
 
 ### <a name="module_terraform_azurerm_avm_res_compute_virtualmachinescaleset"></a> [terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset](#module\_terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset)
 

--- a/examples/upgrade-policy-linux/README.md
+++ b/examples/upgrade-policy-linux/README.md
@@ -219,7 +219,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~>1.15)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.15, < 3.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 

--- a/examples/upgrade-policy-linux/main.tf
+++ b/examples/upgrade-policy-linux/main.tf
@@ -6,7 +6,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 

--- a/examples/upgrade-policy-linux/terraform.tf
+++ b/examples/upgrade-policy-linux/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~>1.15"
+      version = ">= 1.15, < 3.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/upgrade-policy-linux/terraform.tf
+++ b/examples/upgrade-policy-linux/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/upgrade-policy-windows/README.md
+++ b/examples/upgrade-policy-windows/README.md
@@ -22,7 +22,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 
@@ -223,7 +223,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.0.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)
 
@@ -311,7 +311,7 @@ Version: 0.4.1
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: =0.1.0
+Version: 0.3.0
 
 ### <a name="module_terraform_azurerm_avm_res_compute_virtualmachinescaleset"></a> [terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset](#module\_terraform\_azurerm\_avm\_res\_compute\_virtualmachinescaleset)
 

--- a/examples/upgrade-policy-windows/main.tf
+++ b/examples/upgrade-policy-windows/main.tf
@@ -6,7 +6,7 @@ module "naming" {
 
 module "regions" {
   source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "=0.1.0"
+  version                   = "0.3.0"
   availability_zones_filter = true
 }
 

--- a/examples/upgrade-policy-windows/terraform.tf
+++ b/examples/upgrade-policy-windows/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/sku_selector/README.md
+++ b/modules/sku_selector/README.md
@@ -51,9 +51,9 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.13, != 1.13.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, != 1.13.0, < 3.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/modules/sku_selector/terraform.tf
+++ b/modules/sku_selector/terraform.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 1.13, != 1.13.0"
+      version = ">= 1.13, != 1.13.0, < 3.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~>1.15"
+      version = ">= 1.15, < 3.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 4.0"
+      version = ">= 3.116, < 5.0"
     }
     modtm = {
       source  = "Azure/modtm"


### PR DESCRIPTION
## Description

This PR adjusts the required providers so that we can use AzApi version 2 and AzureRM version 4.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
