### PR TITLE
fix: use azurerm azurerm_orchestrated_virtual_machine_scale_set properties for upgrade_mode and rolling_upgrade_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
-
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.26)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -24,7 +22,6 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_update_resource.set_update_policy](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_orchestrated_virtual_machine_scale_set.virtual_machine_scale_set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/orchestrated_virtual_machine_scale_set) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)

--- a/avm.tflint_module.hcl
+++ b/avm.tflint_module.hcl
@@ -6,7 +6,7 @@ plugin "terraform" {
 
 plugin "avm" {
   enabled     = true
-  version     = "0.13.0"
+  version     = "0.14.1"
   source      = "github.com/Azure/tflint-ruleset-avm"
   signing_key = <<-KEY
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -188,7 +188,7 @@ rule "tags" {
   enabled = true
 }
 
-rule "provider_modtm_version" {
+rule "provider_modtm_version_constraint" {
   enabled = false
 }
 

--- a/examples/autoscale-linux/README.md
+++ b/examples/autoscale-linux/README.md
@@ -21,8 +21,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -143,19 +144,14 @@ resource "tls_private_key" "example_ssh" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  instances                   = 2
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  boot_diagnostics = {
-    storage_account_uri = "" # Enable boot diagnostics
-  }
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
   admin_ssh_keys = [(
     {
       id         = tls_private_key.example_ssh.id
@@ -163,6 +159,20 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       username   = "azureuser"
     }
   )]
+  boot_diagnostics = {
+    storage_account_uri = "" # Enable boot diagnostics
+  }
+  enable_telemetry = var.enable_telemetry
+  extension = [{
+    name                        = "HealthExtension"
+    publisher                   = "Microsoft.ManagedServices"
+    type                        = "ApplicationHealthLinux"
+    type_handler_version        = "1.0"
+    auto_upgrade_minor_version  = true
+    failure_suppression_enabled = false
+    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -180,22 +190,15 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       admin_ssh_key                   = toset([tls_private_key.example_ssh.id])
     }
   }
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
     version   = "latest"
   }
-  extension = [{
-    name                        = "HealthExtension"
-    publisher                   = "Microsoft.ManagedServices"
-    type                        = "ApplicationHealthLinux"
-    type_handler_version        = "1.0"
-    auto_upgrade_minor_version  = true
-    failure_suppression_enabled = false
-    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
-  }]
-  tags       = local.tags
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }
 

--- a/examples/autoscale-linux/main.tf
+++ b/examples/autoscale-linux/main.tf
@@ -5,8 +5,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -127,19 +128,14 @@ resource "tls_private_key" "example_ssh" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  instances                   = 2
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  boot_diagnostics = {
-    storage_account_uri = "" # Enable boot diagnostics
-  }
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
   admin_ssh_keys = [(
     {
       id         = tls_private_key.example_ssh.id
@@ -147,6 +143,20 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       username   = "azureuser"
     }
   )]
+  boot_diagnostics = {
+    storage_account_uri = "" # Enable boot diagnostics
+  }
+  enable_telemetry = var.enable_telemetry
+  extension = [{
+    name                        = "HealthExtension"
+    publisher                   = "Microsoft.ManagedServices"
+    type                        = "ApplicationHealthLinux"
+    type_handler_version        = "1.0"
+    auto_upgrade_minor_version  = true
+    failure_suppression_enabled = false
+    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -164,22 +174,15 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       admin_ssh_key                   = toset([tls_private_key.example_ssh.id])
     }
   }
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
     version   = "latest"
   }
-  extension = [{
-    name                        = "HealthExtension"
-    publisher                   = "Microsoft.ManagedServices"
-    type                        = "ApplicationHealthLinux"
-    type_handler_version        = "1.0"
-    auto_upgrade_minor_version  = true
-    failure_suppression_enabled = false
-    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
-  }]
-  tags       = local.tags
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }
 

--- a/examples/autoscale-windows/README.md
+++ b/examples/autoscale-windows/README.md
@@ -20,8 +20,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -137,20 +138,48 @@ resource "azurerm_subnet_nat_gateway_association" "this" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
-  instances                   = 2
+
   extension_protected_setting = {}
-  admin_ssh_keys              = []
-  user_data_base64            = null
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
+  admin_ssh_keys      = []
   boot_diagnostics = {
     storage_account_uri = "" # Enable boot diagnostics
   }
+  data_disk = [{
+    caching                   = "ReadWrite"
+    create_option             = "Empty"
+    disk_size_gb              = 10
+    lun                       = 0
+    managed_disk_type         = "StandardSSD_LRS"
+    storage_account_type      = "StandardSSD_LRS"
+    write_accelerator_enabled = false
+  }]
+  enable_telemetry = var.enable_telemetry
+  extension = [
+    {
+      name                        = "CustomScriptExtension"
+      publisher                   = "Microsoft.Compute"
+      type                        = "CustomScriptExtension"
+      type_handler_version        = "1.10"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
+    },
+    {
+      name                        = "HealthExtension"
+      publisher                   = "Microsoft.ManagedServices"
+      type                        = "ApplicationHealthWindows"
+      type_handler_version        = "1.0"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -173,41 +202,15 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       }]
     }
   }
-  data_disk = [{
-    caching                   = "ReadWrite"
-    create_option             = "Empty"
-    disk_size_gb              = 10
-    lun                       = 0
-    managed_disk_type         = "StandardSSD_LRS"
-    storage_account_type      = "StandardSSD_LRS"
-    write_accelerator_enabled = false
-  }]
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "MicrosoftWindowsServer"
     offer     = "WindowsServer"
     sku       = "2022-Datacenter"
     version   = "latest"
   }
-  extension = [
-    {
-      name                        = "CustomScriptExtension"
-      publisher                   = "Microsoft.Compute"
-      type                        = "CustomScriptExtension"
-      type_handler_version        = "1.10"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
-    },
-    {
-      name                        = "HealthExtension"
-      publisher                   = "Microsoft.ManagedServices"
-      type                        = "ApplicationHealthWindows"
-      type_handler_version        = "1.0"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
-  }]
-  tags       = local.tags
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }
 ```

--- a/examples/autoscale-windows/main.tf
+++ b/examples/autoscale-windows/main.tf
@@ -5,8 +5,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -122,20 +123,48 @@ resource "azurerm_subnet_nat_gateway_association" "this" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
-  instances                   = 2
+
   extension_protected_setting = {}
-  admin_ssh_keys              = []
-  user_data_base64            = null
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
+  admin_ssh_keys      = []
   boot_diagnostics = {
     storage_account_uri = "" # Enable boot diagnostics
   }
+  data_disk = [{
+    caching                   = "ReadWrite"
+    create_option             = "Empty"
+    disk_size_gb              = 10
+    lun                       = 0
+    managed_disk_type         = "StandardSSD_LRS"
+    storage_account_type      = "StandardSSD_LRS"
+    write_accelerator_enabled = false
+  }]
+  enable_telemetry = var.enable_telemetry
+  extension = [
+    {
+      name                        = "CustomScriptExtension"
+      publisher                   = "Microsoft.Compute"
+      type                        = "CustomScriptExtension"
+      type_handler_version        = "1.10"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
+    },
+    {
+      name                        = "HealthExtension"
+      publisher                   = "Microsoft.ManagedServices"
+      type                        = "ApplicationHealthWindows"
+      type_handler_version        = "1.0"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -158,40 +187,14 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       }]
     }
   }
-  data_disk = [{
-    caching                   = "ReadWrite"
-    create_option             = "Empty"
-    disk_size_gb              = 10
-    lun                       = 0
-    managed_disk_type         = "StandardSSD_LRS"
-    storage_account_type      = "StandardSSD_LRS"
-    write_accelerator_enabled = false
-  }]
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "MicrosoftWindowsServer"
     offer     = "WindowsServer"
     sku       = "2022-Datacenter"
     version   = "latest"
   }
-  extension = [
-    {
-      name                        = "CustomScriptExtension"
-      publisher                   = "Microsoft.Compute"
-      type                        = "CustomScriptExtension"
-      type_handler_version        = "1.10"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
-    },
-    {
-      name                        = "HealthExtension"
-      publisher                   = "Microsoft.ManagedServices"
-      type                        = "ApplicationHealthWindows"
-      type_handler_version        = "1.0"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
-  }]
-  tags       = local.tags
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }

--- a/examples/default-linux/README.md
+++ b/examples/default-linux/README.md
@@ -21,8 +21,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -143,19 +144,14 @@ resource "tls_private_key" "example_ssh" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  instances                   = 2
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  boot_diagnostics = {
-    storage_account_uri = "" # Enable boot diagnostics
-  }
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
   admin_ssh_keys = [(
     {
       id         = tls_private_key.example_ssh.id
@@ -163,6 +159,20 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       username   = "azureuser"
     }
   )]
+  boot_diagnostics = {
+    storage_account_uri = "" # Enable boot diagnostics
+  }
+  enable_telemetry = var.enable_telemetry
+  extension = [{
+    name                        = "HealthExtension"
+    publisher                   = "Microsoft.ManagedServices"
+    type                        = "ApplicationHealthLinux"
+    type_handler_version        = "1.0"
+    auto_upgrade_minor_version  = true
+    failure_suppression_enabled = false
+    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -180,22 +190,15 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       admin_ssh_key                   = toset([tls_private_key.example_ssh.id])
     }
   }
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
     version   = "latest"
   }
-  extension = [{
-    name                        = "HealthExtension"
-    publisher                   = "Microsoft.ManagedServices"
-    type                        = "ApplicationHealthLinux"
-    type_handler_version        = "1.0"
-    auto_upgrade_minor_version  = true
-    failure_suppression_enabled = false
-    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
-  }]
   tags = local.tags
+
   # Uncomment the code below to implement a VMSS Lock
   #lock = {
   #  name = "VMSSNoDelete"

--- a/examples/default-linux/main.tf
+++ b/examples/default-linux/main.tf
@@ -5,8 +5,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -127,19 +128,14 @@ resource "tls_private_key" "example_ssh" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  instances                   = 2
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  boot_diagnostics = {
-    storage_account_uri = "" # Enable boot diagnostics
-  }
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
   admin_ssh_keys = [(
     {
       id         = tls_private_key.example_ssh.id
@@ -147,6 +143,20 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       username   = "azureuser"
     }
   )]
+  boot_diagnostics = {
+    storage_account_uri = "" # Enable boot diagnostics
+  }
+  enable_telemetry = var.enable_telemetry
+  extension = [{
+    name                        = "HealthExtension"
+    publisher                   = "Microsoft.ManagedServices"
+    type                        = "ApplicationHealthLinux"
+    type_handler_version        = "1.0"
+    auto_upgrade_minor_version  = true
+    failure_suppression_enabled = false
+    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -164,22 +174,15 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       admin_ssh_key                   = toset([tls_private_key.example_ssh.id])
     }
   }
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
     version   = "latest"
   }
-  extension = [{
-    name                        = "HealthExtension"
-    publisher                   = "Microsoft.ManagedServices"
-    type                        = "ApplicationHealthLinux"
-    type_handler_version        = "1.0"
-    auto_upgrade_minor_version  = true
-    failure_suppression_enabled = false
-    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
-  }]
   tags = local.tags
+
   # Uncomment the code below to implement a VMSS Lock
   #lock = {
   #  name = "VMSSNoDelete"

--- a/examples/default-windows/README.md
+++ b/examples/default-windows/README.md
@@ -20,8 +20,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -137,20 +138,48 @@ resource "azurerm_subnet_nat_gateway_association" "this" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
-  instances                   = 2
+
   extension_protected_setting = {}
-  admin_ssh_keys              = []
-  user_data_base64            = null
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
+  admin_ssh_keys      = []
   boot_diagnostics = {
     storage_account_uri = "" # Enable boot diagnostics
   }
+  data_disk = [{
+    caching                   = "ReadWrite"
+    create_option             = "Empty"
+    disk_size_gb              = 10
+    lun                       = 0
+    managed_disk_type         = "StandardSSD_LRS"
+    storage_account_type      = "StandardSSD_LRS"
+    write_accelerator_enabled = false
+  }]
+  enable_telemetry = var.enable_telemetry
+  extension = [
+    {
+      name                        = "CustomScriptExtension"
+      publisher                   = "Microsoft.Compute"
+      type                        = "CustomScriptExtension"
+      type_handler_version        = "1.10"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
+    },
+    {
+      name                        = "HealthExtension"
+      publisher                   = "Microsoft.ManagedServices"
+      type                        = "ApplicationHealthWindows"
+      type_handler_version        = "1.0"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -173,41 +202,15 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       }]
     }
   }
-  data_disk = [{
-    caching                   = "ReadWrite"
-    create_option             = "Empty"
-    disk_size_gb              = 10
-    lun                       = 0
-    managed_disk_type         = "StandardSSD_LRS"
-    storage_account_type      = "StandardSSD_LRS"
-    write_accelerator_enabled = false
-  }]
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "MicrosoftWindowsServer"
     offer     = "WindowsServer"
     sku       = "2022-Datacenter"
     version   = "latest"
   }
-  extension = [
-    {
-      name                        = "CustomScriptExtension"
-      publisher                   = "Microsoft.Compute"
-      type                        = "CustomScriptExtension"
-      type_handler_version        = "1.10"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
-    },
-    {
-      name                        = "HealthExtension"
-      publisher                   = "Microsoft.ManagedServices"
-      type                        = "ApplicationHealthWindows"
-      type_handler_version        = "1.0"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
-  }]
-  tags       = local.tags
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }
 ```

--- a/examples/default-windows/main.tf
+++ b/examples/default-windows/main.tf
@@ -5,8 +5,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -122,20 +123,48 @@ resource "azurerm_subnet_nat_gateway_association" "this" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
-  instances                   = 2
+
   extension_protected_setting = {}
-  admin_ssh_keys              = []
-  user_data_base64            = null
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
+  admin_ssh_keys      = []
   boot_diagnostics = {
     storage_account_uri = "" # Enable boot diagnostics
   }
+  data_disk = [{
+    caching                   = "ReadWrite"
+    create_option             = "Empty"
+    disk_size_gb              = 10
+    lun                       = 0
+    managed_disk_type         = "StandardSSD_LRS"
+    storage_account_type      = "StandardSSD_LRS"
+    write_accelerator_enabled = false
+  }]
+  enable_telemetry = var.enable_telemetry
+  extension = [
+    {
+      name                        = "CustomScriptExtension"
+      publisher                   = "Microsoft.Compute"
+      type                        = "CustomScriptExtension"
+      type_handler_version        = "1.10"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
+    },
+    {
+      name                        = "HealthExtension"
+      publisher                   = "Microsoft.ManagedServices"
+      type                        = "ApplicationHealthWindows"
+      type_handler_version        = "1.0"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -158,40 +187,14 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       }]
     }
   }
-  data_disk = [{
-    caching                   = "ReadWrite"
-    create_option             = "Empty"
-    disk_size_gb              = 10
-    lun                       = 0
-    managed_disk_type         = "StandardSSD_LRS"
-    storage_account_type      = "StandardSSD_LRS"
-    write_accelerator_enabled = false
-  }]
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "MicrosoftWindowsServer"
     offer     = "WindowsServer"
     sku       = "2022-Datacenter"
     version   = "latest"
   }
-  extension = [
-    {
-      name                        = "CustomScriptExtension"
-      publisher                   = "Microsoft.Compute"
-      type                        = "CustomScriptExtension"
-      type_handler_version        = "1.10"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
-    },
-    {
-      name                        = "HealthExtension"
-      publisher                   = "Microsoft.ManagedServices"
-      type                        = "ApplicationHealthWindows"
-      type_handler_version        = "1.0"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
-  }]
-  tags       = local.tags
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }

--- a/examples/rbac-and-mi-linux/README.md
+++ b/examples/rbac-and-mi-linux/README.md
@@ -20,8 +20,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -151,18 +152,14 @@ data "azurerm_client_config" "current" {}
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  platform_fault_domain_count = 1
-  admin_password              = "P@ssw0rd1234!"
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
-  instances                   = 2
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  automatic_instance_repair   = null
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
   admin_ssh_keys = [(
     {
       id         = tls_private_key.example_ssh.id
@@ -170,6 +167,24 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       username   = "azureuser"
     }
   )]
+  automatic_instance_repair = null
+  enable_telemetry          = var.enable_telemetry
+  extension = [{
+    name                        = "HealthExtension"
+    publisher                   = "Microsoft.ManagedServices"
+    type                        = "ApplicationHealthLinux"
+    type_handler_version        = "1.0"
+    auto_upgrade_minor_version  = true
+    failure_suppression_enabled = false
+    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
+  }]
+  instances = 2
+  managed_identities = {
+    system_assigned = false
+    user_assigned_resource_ids = [
+      azurerm_user_assigned_identity.user_identity.id
+    ]
+  }
   network_interface = [{
     name = "VMSS-NIC"
     ip_configuration = [{
@@ -186,27 +201,7 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       admin_ssh_key                   = toset([tls_private_key.example_ssh.id])
     }
   }
-  source_image_reference = {
-    publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
-    version   = "latest"
-  }
-  extension = [{
-    name                        = "HealthExtension"
-    publisher                   = "Microsoft.ManagedServices"
-    type                        = "ApplicationHealthLinux"
-    type_handler_version        = "1.0"
-    auto_upgrade_minor_version  = true
-    failure_suppression_enabled = false
-    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
-  }]
-  managed_identities = {
-    system_assigned = false
-    user_assigned_resource_ids = [
-      azurerm_user_assigned_identity.user_identity.id
-    ]
-  }
+  platform_fault_domain_count = 1
   role_assignments = {
     role_assignment = {
       principal_id               = data.azurerm_client_config.current.object_id
@@ -214,7 +209,15 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       description                = "Assign the Reader role to the deployment user on this virtual machine scale set resource scope."
     }
   }
-  tags       = local.tags
+  sku_name = module.get_valid_sku_for_deployment_region.sku
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
+    version   = "latest"
+  }
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }
 ```

--- a/examples/rbac-and-mi-linux/main.tf
+++ b/examples/rbac-and-mi-linux/main.tf
@@ -5,8 +5,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -136,18 +137,14 @@ data "azurerm_client_config" "current" {}
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  platform_fault_domain_count = 1
-  admin_password              = "P@ssw0rd1234!"
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
-  instances                   = 2
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  automatic_instance_repair   = null
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
   admin_ssh_keys = [(
     {
       id         = tls_private_key.example_ssh.id
@@ -155,6 +152,24 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       username   = "azureuser"
     }
   )]
+  automatic_instance_repair = null
+  enable_telemetry          = var.enable_telemetry
+  extension = [{
+    name                        = "HealthExtension"
+    publisher                   = "Microsoft.ManagedServices"
+    type                        = "ApplicationHealthLinux"
+    type_handler_version        = "1.0"
+    auto_upgrade_minor_version  = true
+    failure_suppression_enabled = false
+    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
+  }]
+  instances = 2
+  managed_identities = {
+    system_assigned = false
+    user_assigned_resource_ids = [
+      azurerm_user_assigned_identity.user_identity.id
+    ]
+  }
   network_interface = [{
     name = "VMSS-NIC"
     ip_configuration = [{
@@ -171,27 +186,7 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       admin_ssh_key                   = toset([tls_private_key.example_ssh.id])
     }
   }
-  source_image_reference = {
-    publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-jammy"
-    sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
-    version   = "latest"
-  }
-  extension = [{
-    name                        = "HealthExtension"
-    publisher                   = "Microsoft.ManagedServices"
-    type                        = "ApplicationHealthLinux"
-    type_handler_version        = "1.0"
-    auto_upgrade_minor_version  = true
-    failure_suppression_enabled = false
-    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
-  }]
-  managed_identities = {
-    system_assigned = false
-    user_assigned_resource_ids = [
-      azurerm_user_assigned_identity.user_identity.id
-    ]
-  }
+  platform_fault_domain_count = 1
   role_assignments = {
     role_assignment = {
       principal_id               = data.azurerm_client_config.current.object_id
@@ -199,6 +194,14 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       description                = "Assign the Reader role to the deployment user on this virtual machine scale set resource scope."
     }
   }
-  tags       = local.tags
+  sku_name = module.get_valid_sku_for_deployment_region.sku
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
+    version   = "latest"
+  }
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }

--- a/examples/rbac-and-mi-windows/main.tf
+++ b/examples/rbac-and-mi-windows/main.tf
@@ -5,8 +5,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -131,18 +132,42 @@ data "azurerm_client_config" "current" {}
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  platform_fault_domain_count = 1
-  admin_password              = "P@ssw0rd1234!"
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
-  instances                   = 2
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  automatic_instance_repair   = null
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                      = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name       = azurerm_resource_group.this.name
+  user_data_base64          = null
+  admin_password            = "P@ssw0rd1234!"
+  automatic_instance_repair = null
+  enable_telemetry          = var.enable_telemetry
+  extension = [
+    {
+      name                        = "CustomScriptExtension"
+      publisher                   = "Microsoft.Compute"
+      type                        = "CustomScriptExtension"
+      type_handler_version        = "1.10"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
+    },
+    {
+      name                        = "HealthExtension"
+      publisher                   = "Microsoft.ManagedServices"
+      type                        = "ApplicationHealthWindows"
+      type_handler_version        = "1.0"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
+  }]
+  instances = 2
+  managed_identities = {
+    system_assigned = false
+    user_assigned_resource_ids = [
+      azurerm_user_assigned_identity.user_identity.id
+    ]
+  }
   network_interface = [{
     name = "VMSS-NIC"
     ip_configuration = [{
@@ -164,37 +189,7 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       }]
     }
   }
-  source_image_reference = {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2022-Datacenter"
-    version   = "latest"
-  }
-  extension = [
-    {
-      name                        = "CustomScriptExtension"
-      publisher                   = "Microsoft.Compute"
-      type                        = "CustomScriptExtension"
-      type_handler_version        = "1.10"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
-    },
-    {
-      name                        = "HealthExtension"
-      publisher                   = "Microsoft.ManagedServices"
-      type                        = "ApplicationHealthWindows"
-      type_handler_version        = "1.0"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
-  }]
-  managed_identities = {
-    system_assigned = false
-    user_assigned_resource_ids = [
-      azurerm_user_assigned_identity.user_identity.id
-    ]
-  }
+  platform_fault_domain_count = 1
   role_assignments = {
     role_assignment = {
       principal_id               = data.azurerm_client_config.current.object_id
@@ -202,6 +197,14 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       description                = "Assign the Reader role to the deployment user on this virtual machine scale set resource scope."
     }
   }
-  tags       = local.tags
+  sku_name = module.get_valid_sku_for_deployment_region.sku
+  source_image_reference = {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-Datacenter"
+    version   = "latest"
+  }
+  tags = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }

--- a/examples/upgrade-policy-linux/README.md
+++ b/examples/upgrade-policy-linux/README.md
@@ -22,8 +22,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -144,19 +145,14 @@ resource "tls_private_key" "example_ssh" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  instances                   = 1
-  sku_name                    = "Standard_B1ms"
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  boot_diagnostics = {
-    storage_account_uri = "" # Enable boot diagnostics
-  }
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
   admin_ssh_keys = [(
     {
       id         = tls_private_key.example_ssh.id
@@ -164,6 +160,20 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       username   = "azureuser"
     }
   )]
+  boot_diagnostics = {
+    storage_account_uri = "" # Enable boot diagnostics
+  }
+  enable_telemetry = var.enable_telemetry
+  extension = [{
+    name                        = "HealthExtension"
+    publisher                   = "Microsoft.ManagedServices"
+    type                        = "ApplicationHealthLinux"
+    type_handler_version        = "1.0"
+    auto_upgrade_minor_version  = true
+    failure_suppression_enabled = false
+    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
+  }]
+  instances = 1
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -181,25 +191,18 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       admin_ssh_key                   = toset([tls_private_key.example_ssh.id])
     }
   }
+  sku_name = "Standard_B1ms"
   source_image_reference = {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
     version   = "latest"
   }
-  extension = [{
-    name                        = "HealthExtension"
-    publisher                   = "Microsoft.ManagedServices"
-    type                        = "ApplicationHealthLinux"
-    type_handler_version        = "1.0"
-    auto_upgrade_minor_version  = true
-    failure_suppression_enabled = false
-    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
-  }]
+  tags = local.tags
   upgrade_policy = {
     upgrade_mode = "Automatic"
   }
-  tags = local.tags
+
   # Uncomment the code below to implement a VMSS Lock
   #lock = {
   #  name = "VMSSNoDelete"

--- a/examples/upgrade-policy-linux/README.md
+++ b/examples/upgrade-policy-linux/README.md
@@ -219,8 +219,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
-
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.6.2)

--- a/examples/upgrade-policy-linux/main.tf
+++ b/examples/upgrade-policy-linux/main.tf
@@ -5,8 +5,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -127,19 +128,14 @@ resource "tls_private_key" "example_ssh" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  instances                   = 1
-  sku_name                    = "Standard_B1ms"
+
   extension_protected_setting = {}
-  user_data_base64            = null
-  boot_diagnostics = {
-    storage_account_uri = "" # Enable boot diagnostics
-  }
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
   admin_ssh_keys = [(
     {
       id         = tls_private_key.example_ssh.id
@@ -147,6 +143,20 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       username   = "azureuser"
     }
   )]
+  boot_diagnostics = {
+    storage_account_uri = "" # Enable boot diagnostics
+  }
+  enable_telemetry = var.enable_telemetry
+  extension = [{
+    name                        = "HealthExtension"
+    publisher                   = "Microsoft.ManagedServices"
+    type                        = "ApplicationHealthLinux"
+    type_handler_version        = "1.0"
+    auto_upgrade_minor_version  = true
+    failure_suppression_enabled = false
+    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
+  }]
+  instances = 1
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -164,25 +174,18 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       admin_ssh_key                   = toset([tls_private_key.example_ssh.id])
     }
   }
+  sku_name = "Standard_B1ms"
   source_image_reference = {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2" # Auto guest patching is enabled on this sku.  https://learn.microsoft.com/en-us/azure/virtual-machines/automatic-vm-guest-patching
     version   = "latest"
   }
-  extension = [{
-    name                        = "HealthExtension"
-    publisher                   = "Microsoft.ManagedServices"
-    type                        = "ApplicationHealthLinux"
-    type_handler_version        = "1.0"
-    auto_upgrade_minor_version  = true
-    failure_suppression_enabled = false
-    settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"/index.html\"}"
-  }]
+  tags = local.tags
   upgrade_policy = {
     upgrade_mode = "Automatic"
   }
-  tags = local.tags
+
   # Uncomment the code below to implement a VMSS Lock
   #lock = {
   #  name = "VMSSNoDelete"

--- a/examples/upgrade-policy-linux/terraform.tf
+++ b/examples/upgrade-policy-linux/terraform.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = ">= 1.9, < 2.0"
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -26,8 +22,4 @@ provider "azurerm" {
       prevent_deletion_if_contains_resources = false
     }
   }
-}
-
-provider "azapi" {
-  use_msi = false
 }

--- a/examples/upgrade-policy-windows/README.md
+++ b/examples/upgrade-policy-windows/README.md
@@ -21,8 +21,9 @@ module "naming" {
 }
 
 module "regions" {
-  source                    = "Azure/avm-utl-regions/azurerm"
-  version                   = "0.3.0"
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+
   availability_zones_filter = true
 }
 
@@ -138,20 +139,48 @@ resource "azurerm_subnet_nat_gateway_association" "this" {
 # This is the module call
 module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
   source = "../../"
-  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
-  name                        = module.naming.virtual_machine_scale_set.name_unique
-  resource_group_name         = azurerm_resource_group.this.name
-  enable_telemetry            = var.enable_telemetry
-  location                    = azurerm_resource_group.this.location
-  admin_password              = "P@ssw0rd1234!"
-  sku_name                    = module.get_valid_sku_for_deployment_region.sku
-  instances                   = 2
+
   extension_protected_setting = {}
-  admin_ssh_keys              = []
-  user_data_base64            = null
+  location                    = azurerm_resource_group.this.location
+  # source             = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
+  name                = module.naming.virtual_machine_scale_set.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  user_data_base64    = null
+  admin_password      = "P@ssw0rd1234!"
+  admin_ssh_keys      = []
   boot_diagnostics = {
     storage_account_uri = "" # Enable boot diagnostics
   }
+  data_disk = [{
+    caching                   = "ReadWrite"
+    create_option             = "Empty"
+    disk_size_gb              = 10
+    lun                       = 0
+    managed_disk_type         = "StandardSSD_LRS"
+    storage_account_type      = "StandardSSD_LRS"
+    write_accelerator_enabled = false
+  }]
+  enable_telemetry = var.enable_telemetry
+  extension = [
+    {
+      name                        = "CustomScriptExtension"
+      publisher                   = "Microsoft.Compute"
+      type                        = "CustomScriptExtension"
+      type_handler_version        = "1.10"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
+    },
+    {
+      name                        = "HealthExtension"
+      publisher                   = "Microsoft.ManagedServices"
+      type                        = "ApplicationHealthWindows"
+      type_handler_version        = "1.0"
+      auto_upgrade_minor_version  = true
+      failure_suppression_enabled = false
+      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
+  }]
+  instances = 2
   network_interface = [{
     name                      = "VMSS-NIC"
     network_security_group_id = azurerm_network_security_group.nic.id
@@ -174,44 +203,18 @@ module "terraform_azurerm_avm_res_compute_virtualmachinescaleset" {
       }]
     }
   }
-  data_disk = [{
-    caching                   = "ReadWrite"
-    create_option             = "Empty"
-    disk_size_gb              = 10
-    lun                       = 0
-    managed_disk_type         = "StandardSSD_LRS"
-    storage_account_type      = "StandardSSD_LRS"
-    write_accelerator_enabled = false
-  }]
+  sku_name = module.get_valid_sku_for_deployment_region.sku
   source_image_reference = {
     publisher = "MicrosoftWindowsServer"
     offer     = "WindowsServer"
     sku       = "2022-Datacenter"
     version   = "latest"
   }
-  extension = [
-    {
-      name                        = "CustomScriptExtension"
-      publisher                   = "Microsoft.Compute"
-      type                        = "CustomScriptExtension"
-      type_handler_version        = "1.10"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"commandToExecute\":\"copy %SYSTEMDRIVE%\\\\AzureData\\\\CustomData.bin c:\\\\init-script.ps1 \\u0026 powershell -ExecutionPolicy Unrestricted -File %SYSTEMDRIVE%\\\\init-script.ps1\"}"
-    },
-    {
-      name                        = "HealthExtension"
-      publisher                   = "Microsoft.ManagedServices"
-      type                        = "ApplicationHealthWindows"
-      type_handler_version        = "1.0"
-      auto_upgrade_minor_version  = true
-      failure_suppression_enabled = false
-      settings                    = "{\"port\":80,\"protocol\":\"http\",\"requestPath\":\"index.html\"}"
-  }]
+  tags = local.tags
   upgrade_policy = {
     upgrade_mode = "Automatic"
   }
-  tags       = local.tags
+
   depends_on = [azurerm_subnet_nat_gateway_association.this]
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -274,12 +274,12 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "virtual_machine_scale
     for_each = var.upgrade_policy.upgrade_mode == "Rolling" ? [var.upgrade_policy.rolling_upgrade_policy] : []
 
     content {
-      cross_zone_upgrades_enabled             = rolling_upgrade_policy.value.cross_zone_upgrades_enabled
       max_batch_instance_percent              = rolling_upgrade_policy.value.max_batch_instance_percent
       max_unhealthy_instance_percent          = rolling_upgrade_policy.value.max_unhealthy_instance_percent
       max_unhealthy_upgraded_instance_percent = rolling_upgrade_policy.value.max_unhealthy_upgraded_instance_percent
-      maximum_surge_instances_enabled         = rolling_upgrade_policy.value.maximum_surge_instances_enabled
       pause_time_between_batches              = rolling_upgrade_policy.value.pause_time_between_batches
+      cross_zone_upgrades_enabled             = rolling_upgrade_policy.value.cross_zone_upgrades_enabled
+      maximum_surge_instances_enabled         = rolling_upgrade_policy.value.maximum_surge_instances_enabled
       prioritize_unhealthy_instances_enabled  = rolling_upgrade_policy.value.prioritize_unhealthy_instances_enabled
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "virtual_machine_scale
   sku_name                      = var.sku_name
   source_image_id               = var.source_image_id
   tags                          = var.tags
+  upgrade_mode                  = var.upgrade_policy.upgrade_mode
   user_data_base64              = var.user_data_base64
   zone_balance                  = var.zone_balance
   zones                         = var.zones
@@ -269,6 +270,19 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "virtual_machine_scale
       regular_percentage_above_base = priority_mix.value.regular_percentage_above_base
     }
   }
+  dynamic "rolling_upgrade_policy" {
+    for_each = var.upgrade_policy.upgrade_mode == "Rolling" ? [var.upgrade_policy.rolling_upgrade_policy] : []
+
+    content {
+      cross_zone_upgrades_enabled             = rolling_upgrade_policy.value.cross_zone_upgrades_enabled
+      max_batch_instance_percent              = rolling_upgrade_policy.value.max_batch_instance_percent
+      max_unhealthy_instance_percent          = rolling_upgrade_policy.value.max_unhealthy_instance_percent
+      max_unhealthy_upgraded_instance_percent = rolling_upgrade_policy.value.max_unhealthy_upgraded_instance_percent
+      maximum_surge_instances_enabled         = rolling_upgrade_policy.value.maximum_surge_instances_enabled
+      pause_time_between_batches              = rolling_upgrade_policy.value.pause_time_between_batches
+      prioritize_unhealthy_instances_enabled  = rolling_upgrade_policy.value.prioritize_unhealthy_instances_enabled
+    }
+  }
   dynamic "source_image_reference" {
     for_each = var.source_image_reference == null ? [] : [var.source_image_reference]
 
@@ -297,36 +311,6 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "virtual_machine_scale
       update = timeouts.value.update
     }
   }
-}
-
-resource "azapi_update_resource" "set_update_policy" {
-  type = "Microsoft.Compute/virtualMachineScaleSets@2024-07-01"
-  body = merge(
-    var.upgrade_policy.upgrade_mode != "Rolling" ? {
-      properties = {
-        upgradePolicy = {
-          mode = var.upgrade_policy.upgrade_mode
-        }
-      }
-    } : {},
-    var.upgrade_policy.upgrade_mode == "Rolling" ? {
-      properties = {
-        upgradePolicy = {
-          mode = var.upgrade_policy.upgrade_mode
-          rollingUpgradePolicy = {
-            enableCrossZoneUpgrade              = var.upgrade_policy.rolling_upgrade_policy.cross_zone_upgrades_enabled
-            maxBatchInstancePercent             = var.upgrade_policy.rolling_upgrade_policy.max_batch_instance_percent
-            maxUnhealthyInstancePercent         = var.upgrade_policy.rolling_upgrade_policy.max_unhealthy_instance_percent
-            maxUnhealthyUpgradedInstancePercent = var.upgrade_policy.rolling_upgrade_policy.max_unhealthy_upgraded_instance_percent
-            pauseTimeBetweenBatches             = var.upgrade_policy.rolling_upgrade_policy.pause_time_between_batches
-            prioritizeUnhealthyInstances        = var.upgrade_policy.rolling_upgrade_policy.prioritize_unhealthy_instances_enabled
-            maxSurge                            = var.upgrade_policy.rolling_upgrade_policy.maximum_surge_instances_enabled
-          }
-        }
-      }
-    } : {}
-  )
-  resource_id = azurerm_orchestrated_virtual_machine_scale_set.virtual_machine_scale_set.id
 }
 
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,13 +1,9 @@
 terraform {
   required_version = ">= 1.9, < 2.0"
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     modtm = {
       source  = "Azure/modtm"


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

With the release of version [v4.26.0](https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v4.26.0) of the Azure RM provider, the `azurerm_orchestrated_virtual_machine_scale_set` resource has now support for the `upgrade_mode` and `rolling_upgrade_policy` properties, which removes the need for the AzApi.

Without this fix the VMSS is being replaced, so with this change the VMSS is not replaced anymore.

Fixed #131 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
