### PR TITLE
feat: allow NvmeDisk placement for ephemeral OS disk (Dv6/Edsv6 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Description: - `caching` - (Required) The Type of Caching which should be used f
 ---
 `diff_disk_settings` block supports the following:
 - `option` - (Required) Specifies the Ephemeral Disk Settings for the OS Disk. At this time the only possible value is `Local`. Changing this forces a new resource to be created.
-- `placement` - (Optional) Specifies where to store the Ephemeral Disk. Possible values are `CacheDisk` and `ResourceDisk`. Defaults to `CacheDisk`. Changing this forces a new resource to be created.
+- `placement` - (Optional) Specifies where to store the Ephemeral Disk. Possible values are `CacheDisk`, `ResourceDisk`, and `NvmeDisk`. Defaults to `CacheDisk`. `NvmeDisk` is required for VM sizes that expose only NVMe local storage (e.g. Dv6/Edsv6 family). Changing this forces a new resource to be created.
 
 Type:
 

--- a/variables.tf
+++ b/variables.tf
@@ -569,7 +569,7 @@ variable "os_disk" {
  ---
  `diff_disk_settings` block supports the following:
  - `option` - (Required) Specifies the Ephemeral Disk Settings for the OS Disk. At this time the only possible value is `Local`. Changing this forces a new resource to be created.
- - `placement` - (Optional) Specifies where to store the Ephemeral Disk. Possible values are `CacheDisk` and `ResourceDisk`. Defaults to `CacheDisk`. Changing this forces a new resource to be created.
+ - `placement` - (Optional) Specifies where to store the Ephemeral Disk. Possible values are `CacheDisk`, `ResourceDisk`, and `NvmeDisk`. Defaults to `CacheDisk`. `NvmeDisk` is required for VM sizes that expose only NVMe local storage (e.g. Dv6/Edsv6 family). Changing this forces a new resource to be created.
 EOT
 
   validation {
@@ -585,8 +585,8 @@ EOT
     error_message = "The diff_disk_settings option must be 'Local'."
   }
   validation {
-    condition     = var.os_disk == null ? true : var.os_disk.diff_disk_settings == null ? true : var.os_disk.diff_disk_settings.placement == null ? true : contains(["CacheDisk", "ResourceDisk"], var.os_disk.diff_disk_settings.placement)
-    error_message = "The diff_disk_settings placement must be one of: 'CacheDisk' or 'ResourceDisk'."
+    condition     = var.os_disk == null ? true : var.os_disk.diff_disk_settings == null ? true : var.os_disk.diff_disk_settings.placement == null ? true : contains(["CacheDisk", "ResourceDisk", "NvmeDisk"], var.os_disk.diff_disk_settings.placement)
+    error_message = "The diff_disk_settings placement must be one of: 'CacheDisk', 'ResourceDisk', or 'NvmeDisk'."
   }
 }
 


### PR DESCRIPTION
## Why

VMs in the Dv6/Edsv6 family (e.g. `Standard_D8ds_v6`) expose NVMe local storage instead of a cache disk. Azure requires `placement = NvmeDisk` for ephemeral OS disks on these SKUs and rejects `CacheDisk` / `ResourceDisk` with:

> The Diff Disk Placement of type 'CacheDisk' is not supported for VM size Standard_D8ds_v6.

The module's `main.tf` already passes `diff_disk_settings.placement` through verbatim to the azapi VMSS resource, so the underlying API supports it — only the input variable validation was blocking the value.

## What

- Add `NvmeDisk` to the validation allow-list for `var.os_disk.diff_disk_settings.placement`
- Update inline variable docs and README accordingly

## Test

Verified end-to-end against `Standard_D8ds_v6` with the patched module — VMSS provisions successfully with ephemeral OS disk on NVMe.

## References

- [Ephemeral OS disks for Azure VMs](https://learn.microsoft.com/azure/virtual-machines/ephemeral-os-disks)
- [Dv6-series VM sizes](https://learn.microsoft.com/azure/virtual-machines/sizes/general-purpose/dv6-series)