### PR TITLE
fix: stop existing_vmss drift detection from forcing VMSS replacement

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,31 +3,21 @@
 # single_placement_group changes from false to true, as Azure does not allow
 # either to be updated in place. Both are wired up through
 # replace_triggers_external_values on the scale set resource.
+#
+# This block deliberately carries no lifecycle pre/postconditions. Terraform
+# widens a data source's deferral check from its explicit `depends_on` to its
+# entire transitive dependency closure as soon as the block declares any custom
+# condition. That would defer this read to apply whenever anything upstream of
+# `parent_id` has a pending change, making every value derived from it unknown
+# and forcing a destructive replacement of the scale set. The assertions that
+# used to live here are preconditions on azapi_resource.virtual_machine_scale_set
+# instead, where they carry the same weight without affecting the read.
 data "azapi_resource" "existing_vmss" {
   name                   = var.name
   parent_id              = var.parent_id
   type                   = "Microsoft.Compute/virtualMachineScaleSets@2024-11-01"
   ignore_not_found       = true
   response_export_values = ["*"]
-
-  lifecycle {
-    postcondition {
-      condition = !(
-        self.exists &&
-        try(self.output.sku, null) != null &&
-        try(self.output.properties.virtualMachineProfile, null) == null
-      )
-      error_message = "Existing VMSS must have `properties.virtualMachineProfile` defined for non-legacy scale sets."
-    }
-    postcondition {
-      condition = !(
-        self.exists &&
-        try(self.output.sku, null) != null &&
-        try(self.output.properties.virtualMachineProfile.storageProfile, null) == null
-      )
-      error_message = "Existing VMSS must have `properties.virtualMachineProfile.storageProfile` defined for non-legacy scale sets."
-    }
-  }
 }
 
 moved {
@@ -633,6 +623,26 @@ resource "azapi_resource" "virtual_machine_scale_set" {
       body.zones,
     ]
 
+    # Relocated from data.azapi_resource.existing_vmss. Declaring these on the
+    # data source would force its read to be deferred to apply whenever any
+    # transitive dependency has a pending change; conditions on a managed
+    # resource carry no such penalty.
+    precondition {
+      condition = !(
+        data.azapi_resource.existing_vmss.exists &&
+        try(data.azapi_resource.existing_vmss.output.sku, null) != null &&
+        try(data.azapi_resource.existing_vmss.output.properties.virtualMachineProfile, null) == null
+      )
+      error_message = "Existing VMSS must have `properties.virtualMachineProfile` defined for non-legacy scale sets."
+    }
+    precondition {
+      condition = !(
+        data.azapi_resource.existing_vmss.exists &&
+        try(data.azapi_resource.existing_vmss.output.sku, null) != null &&
+        try(data.azapi_resource.existing_vmss.output.properties.virtualMachineProfile.storageProfile, null) == null
+      )
+      error_message = "Existing VMSS must have `properties.virtualMachineProfile.storageProfile` defined for non-legacy scale sets."
+    }
     precondition {
       condition     = var.zone_balance != true || (var.zones != null && length(var.zones) > 0)
       error_message = "`zone_balance` can only be set to `true` when availability zones are specified."


### PR DESCRIPTION
## Description

Closes #205

`data.azapi_resource.existing_vmss` declared two `lifecycle.postcondition` blocks. Terraform widens a data source's deferral check from its explicit `depends_on` to its **entire transitive dependency closure** as soon as the block declares any custom condition — `internal/terraform/node_resource_abstract_instance.go`:

```go
depsToUse := n.dependsOn                        // explicit depends_on only
if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
    if n.Config.HasCustomConditions() {
        depsToUse = n.Dependencies              // full transitive ancestor closure
    }
}
```

`HasCustomConditions()` is `len(Postconditions) != 0 || len(Preconditions) != 0`, and `n.Dependencies` is built from `g.Ancestors(v)` (`transform_reference.go`). So a pending change *anywhere* upstream of `parent_id` — the reporter's "unrelated role assignment in another resource group" — deferred the read to apply.

### Why that caused a destructive replacement

Every value derived from the data source went unknown, including both entries of `replace_triggers_external_values`. azapi guards that attribute with `RequiresReplaceIfNotNull`, which only bails out when the **outer** value is null on either side:

```go
planNull  := req.PlanValue.IsNull()  || req.PlanValue.UnderlyingValue().IsNull()
stateNull := req.StateValue.IsNull() || req.StateValue.UnderlyingValue().IsNull()
resp.RequiresReplace = !planNull && !stateNull
```

State held a known object of nulls, the plan a known object of unknowns — neither outer value is null, and they are unequal, so `RequiresReplace = true`. The resulting unknown `id` then force-replaced `azurerm_monitor_autoscale_setting` through `target_resource_id`.

`constrainedMaximumCapacity` is a bystander here, not the driver — the `try()` mitigation suggested by automated triage would not have changed the outcome, since `try()` catches errors, not unknown values.

### The fix

Both assertions move onto `azapi_resource.virtual_machine_scale_set` as `precondition`s, into the `lifecycle` block that already holds five of them. `HasCustomConditions` is consulted only for data sources, so conditions on a managed resource carry no deferral penalty. Preconditions also keep hard-error semantics, unlike a `check` block, which would silently downgrade these guardrails to warnings.

### Validation

Reproduced the whole chain with a credential-free harness (`local_file` data source + `terraform_data.triggers_replace`, which carries the same dynamic `RequiresReplace` shape as `replace_triggers_external_values`). Four module variants, identical apart from the stated difference, in a single plan against one pending upstream change:

| variant | condition location | module `depends_on` | result |
| --- | --- | --- | --- |
| `plain` | none | no | read at plan ✅ |
| `guarded` | **on the data source** | no | **deferred** ❌ |
| `plaindep` | none | **yes** | deferred ❌ |
| `precond` | **on the managed resource** | no | read at plan ✅ |
| `preconddep` | on the managed resource | **yes** | deferred, precondition **postponed to apply — no error, no replacement** ✅ |

`guarded` reproduced the issue's plan output verbatim, including `# ... will be read during apply / (depends on a resource or a module with changes pending)` and `+ zones_removal_trigger = (known after apply)` under `must be replaced`.

`terraform fmt -check -recursive` and `terraform validate` both pass.

### Known residual (not addressed here)

A caller that sets `depends_on` on the module block still defers the read, because that path uses `n.dependsOn` regardless of conditions. The other deferral routes are benign: if `parent_id`/`name` are unknown because the resource group is created in the same run, the scale set is not yet in state and `RequiresReplaceIfNotNull` returns early on `State.Raw.IsNull()`; and if the resource group is being replaced, the scale set would be replaced regardless.

Worth noting `replace_triggers_refs` is **not** a viable alternative for the zones trigger — the resource carries `ignore_changes = [body.zones]`, so a body-path ref would never fire. Closing the residual would need an opt-out variable gating the data source; happy to follow up if maintainers want it.

Also observed during testing: `single_placement_group_trigger` stays `null` even when `zones_removal_trigger` goes unknown, confirming Terraform short-circuits `unknown && false` to `false`. That trigger is therefore already unknown-safe whenever `var.single_placement_group != true`.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks



> Note on the checklist: `terraform fmt -check -recursive` and `terraform validate` were run locally and pass. The full `make pre-commit` target needs `porch`, which was not available in my environment, so I am deferring it to CI. The change adds or removes no variables or outputs, so docs regeneration is a no-op.



---

**CI result:** all 23 checks green on `592d0b2`. `hibernation-linux` failed on the first attempt with the known flaky `sku_selector` capacity error (`eligible_skus: 0, hibernation_skus: 0` in `westeurope` — unrelated to this change) and passed on rerun.

The e2e logs also confirm the fix against real Azure:

```\nmodule...data.azapi_resource.existing_vmss: Reading...\nmodule...data.azapi_resource.existing_vmss: Read complete after 0s [id=...]\n```
