### PR TITLE
fix: drop AzureRM provider from sku_selector in favour of azapi_client_config

### DIFF
--- a/modules/sku_selector/README.md
+++ b/modules/sku_selector/README.md
@@ -13,8 +13,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
-
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 
 ## Resources
@@ -22,8 +20,8 @@ The following requirements are needed by this module:
 The following resources are used by this module:
 
 - [random_integer.deploy_sku](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+- [azapi_client_config.current](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
 - [azapi_resource_list.example](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_list) (data source)
-- [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/modules/sku_selector/main.tf
+++ b/modules/sku_selector/main.tf
@@ -1,9 +1,9 @@
 ### this segment of code gets valid vm skus for deployment in the current subscription
-data "azurerm_subscription" "current" {}
+data "azapi_client_config" "current" {}
 
 #get the full sku list (azapi doesn't currently have a good way to filter the api call)
 data "azapi_resource_list" "example" {
-  parent_id              = data.azurerm_subscription.current.id
+  parent_id              = data.azapi_client_config.current.subscription_resource_id
   type                   = "Microsoft.Compute/skus?$filter=location%20eq%20%27${var.deployment_region}%27@2021-07-01"
   response_export_values = ["*"]
 }

--- a/modules/sku_selector/terraform.tf
+++ b/modules/sku_selector/terraform.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "Azure/azapi"
       version = "~> 2.0"
     }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.6"


### PR DESCRIPTION
## Description

Closes #209

`modules/sku_selector` was the last thing in the **module code** still requiring the AzureRM provider, and it used it for exactly one thing — turning the current subscription into `/subscriptions/<id>` for the `parent_id` of the `azapi_resource_list` call on the very next line:

```terraform
data "azurerm_subscription" "current" {}

data "azapi_resource_list" "example" {
  parent_id = data.azurerm_subscription.current.id
  ...
}
```

[`azapi_client_config`](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) exports `subscription_resource_id`, documented as *"The resource ID of the subscription. E.g. `/subscriptions/00000000-0000-0000-0000-000000000000`"* — a drop-in replacement. The submodule already required `azapi` for `azapi_resource_list`, so **no new provider dependency is introduced**; this only removes one.

Per [TFFR3](https://azure.github.io/Azure-Verified-Modules/spec/TFFR3/) (`Severity-MUST`), only `Azure/azapi >= 2.0, < 3.0` is permitted, and AzureRM MUST NOT be used except where functionality is genuinely unavailable through AzAPI. A subscription ID lookup is not such a case.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings <!-- awaiting CI -->
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks <!-- porch unavailable locally; docs regenerated with the same governance config CI uses -->
