### PR TITLE
feat: support metadata security protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,55 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_proxy_agent_settings"></a> [proxy\_agent\_settings](#input\_proxy\_agent\_settings)
+
+Description: (Optional) Metadata Security Protocol (MSP) settings for the Guest Proxy Agent. MSP restricts in-guest access to Azure Instance Metadata Service (IMDS) and WireServer. The selected image must be [compatible with MSP](https://learn.microsoft.com/azure/virtual-machines/metadata-security-protocol/overview#compatibility).
+
+- `enabled` - (Optional) Enables MSP. Defaults to `true` when this object is supplied.
+- `key_incarnation_id` - (Optional) Non-negative integer used to reset the key that secures guest-to-host communication. Increase this value only for recovery or troubleshooting.
+- `add_proxy_agent_extension` - (Optional) Installs or removes the Proxy Agent extension implicitly. This setting is only valid for Linux and defaults to `true`. When omitted for Windows, the property is not sent because Azure installs the Windows extension automatically.
+- `imds` - (Optional) Configuration for the Azure Instance Metadata Service endpoint.
+  - `mode` - (Optional) Inline protection mode. Valid values are `Audit`, `Enforce`, and `Disabled`.
+  - `in_vm_access_control_profile_reference_id` - (Optional) Full resource ID of a Compute Gallery InVMAccessControlProfile version. Cannot be combined with `mode`.
+- `wire_server` - (Optional) Configuration for the WireServer endpoint.
+  - `mode` - (Optional) Inline protection mode. Valid values are `Audit`, `Enforce`, and `Disabled`.
+  - `in_vm_access_control_profile_reference_id` - (Optional) Full resource ID of a Compute Gallery InVMAccessControlProfile version. Cannot be combined with `mode`.
+
+Microsoft recommends starting with both endpoints in `Audit` mode, reviewing the guest audit logs, and then moving to `Enforce`. See <https://learn.microsoft.com/azure/virtual-machines/metadata-security-protocol/configuration>.
+
+Example:
+```hcl
+proxy_agent_settings = {
+  enabled = true
+  imds = {
+    mode = "Audit"
+  }
+  wire_server = {
+    mode = "Audit"
+  }
+}
+```
+
+Type:
+
+```hcl
+object({
+    enabled                   = optional(bool, true)
+    key_incarnation_id        = optional(number)
+    add_proxy_agent_extension = optional(bool)
+    imds = optional(object({
+      mode                                      = optional(string)
+      in_vm_access_control_profile_reference_id = optional(string)
+    }))
+    wire_server = optional(object({
+      mode                                      = optional(string)
+      in_vm_access_control_profile_reference_id = optional(string)
+    }))
+  })
+```
+
+Default: `null`
+
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
 Description:   A map of role assignments to create on the <RESOURCE>. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.

--- a/main.tf
+++ b/main.tf
@@ -141,7 +141,7 @@ resource "azapi_resource" "virtual_machine_scale_set" {
                     var.proxy_agent_settings.imds != null && (
                       var.proxy_agent_settings.imds.mode != null ||
                       var.proxy_agent_settings.imds.in_vm_access_control_profile_reference_id != null
-                    ) ? {
+                      ) ? {
                       imds = merge(
                         var.proxy_agent_settings.imds.mode != null ? {
                           mode = var.proxy_agent_settings.imds.mode
@@ -154,7 +154,7 @@ resource "azapi_resource" "virtual_machine_scale_set" {
                     var.proxy_agent_settings.wire_server != null && (
                       var.proxy_agent_settings.wire_server.mode != null ||
                       var.proxy_agent_settings.wire_server.in_vm_access_control_profile_reference_id != null
-                    ) ? {
+                      ) ? {
                       wireServer = merge(
                         var.proxy_agent_settings.wire_server.mode != null ? {
                           mode = var.proxy_agent_settings.wire_server.mode

--- a/main.tf
+++ b/main.tf
@@ -119,10 +119,54 @@ resource "azapi_resource" "virtual_machine_scale_set" {
                 }
               }
             } : {},
-            var.encryption_at_host_enabled != null ? {
-              securityProfile = {
-                encryptionAtHost = var.encryption_at_host_enabled
-              }
+            var.encryption_at_host_enabled != null || var.proxy_agent_settings != null ? {
+              securityProfile = merge(
+                var.encryption_at_host_enabled != null ? {
+                  encryptionAtHost = var.encryption_at_host_enabled
+                } : {},
+                var.proxy_agent_settings != null ? {
+                  proxyAgentSettings = merge(
+                    {
+                      enabled = var.proxy_agent_settings.enabled
+                    },
+                    var.proxy_agent_settings.key_incarnation_id != null ? {
+                      keyIncarnationId = var.proxy_agent_settings.key_incarnation_id
+                    } : {},
+                    local.is_linux ? {
+                      addProxyAgentExtension = coalesce(
+                        var.proxy_agent_settings.add_proxy_agent_extension,
+                        true
+                      )
+                    } : {},
+                    var.proxy_agent_settings.imds != null && (
+                      var.proxy_agent_settings.imds.mode != null ||
+                      var.proxy_agent_settings.imds.in_vm_access_control_profile_reference_id != null
+                    ) ? {
+                      imds = merge(
+                        var.proxy_agent_settings.imds.mode != null ? {
+                          mode = var.proxy_agent_settings.imds.mode
+                        } : {},
+                        var.proxy_agent_settings.imds.in_vm_access_control_profile_reference_id != null ? {
+                          inVMAccessControlProfileReferenceId = var.proxy_agent_settings.imds.in_vm_access_control_profile_reference_id
+                        } : {}
+                      )
+                    } : {},
+                    var.proxy_agent_settings.wire_server != null && (
+                      var.proxy_agent_settings.wire_server.mode != null ||
+                      var.proxy_agent_settings.wire_server.in_vm_access_control_profile_reference_id != null
+                    ) ? {
+                      wireServer = merge(
+                        var.proxy_agent_settings.wire_server.mode != null ? {
+                          mode = var.proxy_agent_settings.wire_server.mode
+                        } : {},
+                        var.proxy_agent_settings.wire_server.in_vm_access_control_profile_reference_id != null ? {
+                          inVMAccessControlProfileReferenceId = var.proxy_agent_settings.wire_server.in_vm_access_control_profile_reference_id
+                        } : {}
+                      )
+                    } : {}
+                  )
+                } : {}
+              )
             } : {},
             var.eviction_policy != null ? {
               evictionPolicy = var.eviction_policy

--- a/tests/unit/metadata_security_protocol.tftest.hcl
+++ b/tests/unit/metadata_security_protocol.tftest.hcl
@@ -1,0 +1,319 @@
+mock_provider "azapi" {
+  mock_data "azapi_resource" {
+    defaults = {
+      exists = false
+      output = null
+    }
+  }
+
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-msp"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  extension_protected_setting = {}
+  location                    = "eastus"
+  name                        = "vmss-msp"
+  parent_id                   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  automatic_instance_repair   = null
+  admin_password              = "AvmUnitTest123!"
+  admin_password_version      = "1"
+  custom_data                 = base64encode("msp-test")
+  custom_data_version         = "1"
+  encryption_at_host_enabled  = true
+  user_data_base64            = base64encode("msp-test")
+  user_data_base64_version    = "1"
+  network_interface = [{
+    name    = "nic"
+    primary = true
+    ip_configuration = [{
+      name      = "ipconfig"
+      primary   = true
+      subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+    }]
+  }]
+  os_profile = {
+    windows_configuration = {
+      admin_username = "azureuser"
+      patch_mode     = "AutomaticByOS"
+    }
+  }
+  sku_name = "Standard_D2s_v5"
+  source_image_reference = {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-datacenter-g2"
+    version   = "latest"
+  }
+  proxy_agent_settings = {
+    enabled            = true
+    key_incarnation_id = 2
+    imds = {
+      mode = "Audit"
+    }
+    wire_server = {
+      mode = "Enforce"
+    }
+  }
+}
+
+run "windows_inline_proxy_agent_settings" {
+  command = apply
+
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.enabled
+    error_message = "MSP must be enabled in the VMSS security profile."
+  }
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.encryptionAtHost
+    error_message = "Adding MSP must preserve encryption-at-host settings in the shared security profile."
+  }
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.keyIncarnationId == 2
+    error_message = "The proxy agent key incarnation ID must be mapped to the Compute API field."
+  }
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.imds.mode == "Audit"
+    error_message = "The IMDS inline mode must be mapped to proxyAgentSettings."
+  }
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.wireServer.mode == "Enforce"
+    error_message = "The WireServer inline mode must be mapped to proxyAgentSettings."
+  }
+  assert {
+    condition     = !can(azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.addProxyAgentExtension)
+    error_message = "The Linux-only addProxyAgentExtension property must not be sent for Windows."
+  }
+}
+
+run "linux_enables_proxy_agent_extension_by_default" {
+  command = apply
+
+  variables {
+    os_profile = {
+      linux_configuration = {
+        admin_username = "azureuser"
+        patch_mode     = "ImageDefault"
+      }
+    }
+    source_image_reference = {
+      publisher = "Canonical"
+      offer     = "0001-com-ubuntu-server-jammy"
+      sku       = "22_04-lts-gen2"
+      version   = "latest"
+    }
+    proxy_agent_settings = {
+      enabled = true
+      imds = {
+        mode = "Audit"
+      }
+      wire_server = {
+        mode = "Audit"
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.addProxyAgentExtension
+    error_message = "Linux MSP must install the Proxy Agent extension by default when MSP is enabled."
+  }
+}
+
+run "linux_extension_defaults_true_when_msp_is_disabled" {
+  command = apply
+
+  variables {
+    os_profile = {
+      linux_configuration = {
+        admin_username = "azureuser"
+        patch_mode     = "ImageDefault"
+      }
+    }
+    source_image_reference = {
+      publisher = "Canonical"
+      offer     = "0001-com-ubuntu-server-jammy"
+      sku       = "22_04-lts-gen2"
+      version   = "latest"
+    }
+    proxy_agent_settings = {
+      enabled = false
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.addProxyAgentExtension
+    error_message = "Linux must install the Proxy Agent extension by default even when MSP starts disabled."
+  }
+}
+
+run "linux_preserves_explicit_false_for_proxy_agent_extension" {
+  command = apply
+
+  variables {
+    os_profile = {
+      linux_configuration = {
+        admin_username = "azureuser"
+        patch_mode     = "ImageDefault"
+      }
+    }
+    source_image_reference = {
+      publisher = "Canonical"
+      offer     = "0001-com-ubuntu-server-jammy"
+      sku       = "22_04-lts-gen2"
+      version   = "latest"
+    }
+    proxy_agent_settings = {
+      enabled                   = true
+      add_proxy_agent_extension = false
+    }
+  }
+
+  assert {
+    condition     = !azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.addProxyAgentExtension
+    error_message = "An explicit false must prevent automatic Proxy Agent extension installation on Linux."
+  }
+}
+
+run "windows_accepts_false_and_omits_linux_extension_property" {
+  command = apply
+
+  variables {
+    proxy_agent_settings = {
+      enabled                   = true
+      add_proxy_agent_extension = false
+    }
+  }
+
+  assert {
+    condition     = !can(azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.addProxyAgentExtension)
+    error_message = "Windows may explicitly disable implicit extension installation, but the Linux-only API property must be omitted."
+  }
+}
+
+run "empty_endpoint_objects_are_omitted" {
+  command = apply
+
+  variables {
+    proxy_agent_settings = {
+      imds        = {}
+      wire_server = {}
+    }
+  }
+
+  assert {
+    condition     = !can(azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.imds)
+    error_message = "An empty IMDS object must be omitted from the Compute API request."
+  }
+  assert {
+    condition     = !can(azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.wireServer)
+    error_message = "An empty WireServer object must be omitted from the Compute API request."
+  }
+}
+
+run "linked_access_control_profiles" {
+  command = apply
+
+  variables {
+    proxy_agent_settings = {
+      imds = {
+        in_vm_access_control_profile_reference_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/galleries/gallery-test/inVMAccessControlProfiles/imds-profile/versions/1.0.0"
+      }
+      wire_server = {
+        in_vm_access_control_profile_reference_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/galleries/gallery-test/inVMAccessControlProfiles/wireserver-profile/versions/1.0.0"
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.imds.inVMAccessControlProfileReferenceId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/galleries/gallery-test/inVMAccessControlProfiles/imds-profile/versions/1.0.0"
+    error_message = "The IMDS linked access-control profile ID must be mapped unchanged."
+  }
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.virtualMachineProfile.securityProfile.proxyAgentSettings.wireServer.inVMAccessControlProfileReferenceId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/galleries/gallery-test/inVMAccessControlProfiles/wireserver-profile/versions/1.0.0"
+    error_message = "The WireServer linked access-control profile ID must be mapped unchanged."
+  }
+}
+
+run "invalid_endpoint_mode_is_rejected" {
+  command = plan
+
+  variables {
+    proxy_agent_settings = {
+      imds = {
+        mode = "Block"
+      }
+    }
+  }
+
+  expect_failures = [var.proxy_agent_settings]
+}
+
+run "inline_and_linked_endpoint_settings_are_mutually_exclusive" {
+  command = plan
+
+  variables {
+    proxy_agent_settings = {
+      imds = {
+        mode                                      = "Audit"
+        in_vm_access_control_profile_reference_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/galleries/gallery-test/inVMAccessControlProfiles/imds-profile/versions/1.0.0"
+      }
+    }
+  }
+
+  expect_failures = [var.proxy_agent_settings]
+}
+
+run "invalid_linked_profile_id_is_rejected" {
+  command = plan
+
+  variables {
+    proxy_agent_settings = {
+      wire_server = {
+        in_vm_access_control_profile_reference_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/galleries/gallery-test/inVMAccessControlProfiles/wireserver-profile"
+      }
+    }
+  }
+
+  expect_failures = [var.proxy_agent_settings]
+}
+
+run "negative_key_incarnation_id_is_rejected" {
+  command = plan
+
+  variables {
+    proxy_agent_settings = {
+      key_incarnation_id = -1
+    }
+  }
+
+  expect_failures = [var.proxy_agent_settings]
+}
+
+run "fractional_key_incarnation_id_is_rejected" {
+  command = plan
+
+  variables {
+    proxy_agent_settings = {
+      key_incarnation_id = 1.5
+    }
+  }
+
+  expect_failures = [var.proxy_agent_settings]
+}
+
+run "linux_extension_setting_is_rejected_for_windows" {
+  command = plan
+
+  variables {
+    proxy_agent_settings = {
+      add_proxy_agent_extension = true
+    }
+  }
+
+  expect_failures = [var.proxy_agent_settings]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -808,6 +808,91 @@ variable "proximity_placement_group_id" {
   description = "(Optional) The ID of the Proximity Placement Group which the Orchestrated Virtual Machine should be assigned to. Changing this forces a new resource to be created."
 }
 
+variable "proxy_agent_settings" {
+  type = object({
+    enabled                   = optional(bool, true)
+    key_incarnation_id        = optional(number)
+    add_proxy_agent_extension = optional(bool)
+    imds = optional(object({
+      mode                                      = optional(string)
+      in_vm_access_control_profile_reference_id = optional(string)
+    }))
+    wire_server = optional(object({
+      mode                                      = optional(string)
+      in_vm_access_control_profile_reference_id = optional(string)
+    }))
+  })
+  default     = null
+  description = <<-EOT
+(Optional) Metadata Security Protocol (MSP) settings for the Guest Proxy Agent. MSP restricts in-guest access to Azure Instance Metadata Service (IMDS) and WireServer. The selected image must be [compatible with MSP](https://learn.microsoft.com/azure/virtual-machines/metadata-security-protocol/overview#compatibility).
+
+- `enabled` - (Optional) Enables MSP. Defaults to `true` when this object is supplied.
+- `key_incarnation_id` - (Optional) Non-negative integer used to reset the key that secures guest-to-host communication. Increase this value only for recovery or troubleshooting.
+- `add_proxy_agent_extension` - (Optional) Installs or removes the Proxy Agent extension implicitly. This setting is only valid for Linux and defaults to `true`. When omitted for Windows, the property is not sent because Azure installs the Windows extension automatically.
+- `imds` - (Optional) Configuration for the Azure Instance Metadata Service endpoint.
+  - `mode` - (Optional) Inline protection mode. Valid values are `Audit`, `Enforce`, and `Disabled`.
+  - `in_vm_access_control_profile_reference_id` - (Optional) Full resource ID of a Compute Gallery InVMAccessControlProfile version. Cannot be combined with `mode`.
+- `wire_server` - (Optional) Configuration for the WireServer endpoint.
+  - `mode` - (Optional) Inline protection mode. Valid values are `Audit`, `Enforce`, and `Disabled`.
+  - `in_vm_access_control_profile_reference_id` - (Optional) Full resource ID of a Compute Gallery InVMAccessControlProfile version. Cannot be combined with `mode`.
+
+Microsoft recommends starting with both endpoints in `Audit` mode, reviewing the guest audit logs, and then moving to `Enforce`. See <https://learn.microsoft.com/azure/virtual-machines/metadata-security-protocol/configuration>.
+
+Example:
+```hcl
+proxy_agent_settings = {
+  enabled = true
+  imds = {
+    mode = "Audit"
+  }
+  wire_server = {
+    mode = "Audit"
+  }
+}
+```
+EOT
+
+  validation {
+    condition = var.proxy_agent_settings == null || var.proxy_agent_settings.key_incarnation_id == null || (
+      var.proxy_agent_settings.key_incarnation_id >= 0 &&
+      floor(var.proxy_agent_settings.key_incarnation_id) == var.proxy_agent_settings.key_incarnation_id
+    )
+    error_message = "`proxy_agent_settings.key_incarnation_id` must be a non-negative integer."
+  }
+  validation {
+    condition = var.proxy_agent_settings == null || alltrue([
+      for endpoint in [var.proxy_agent_settings.imds, var.proxy_agent_settings.wire_server] :
+      endpoint == null || endpoint.mode == null || contains(["Audit", "Enforce", "Disabled"], endpoint.mode)
+    ])
+    error_message = "The proxy agent endpoint `mode` must be one of `Audit`, `Enforce`, or `Disabled`."
+  }
+  validation {
+    condition = var.proxy_agent_settings == null || alltrue([
+      for endpoint in [var.proxy_agent_settings.imds, var.proxy_agent_settings.wire_server] :
+      endpoint == null || endpoint.mode == null || endpoint.in_vm_access_control_profile_reference_id == null
+    ])
+    error_message = "A proxy agent endpoint cannot set both `mode` and `in_vm_access_control_profile_reference_id`."
+  }
+  validation {
+    condition = var.proxy_agent_settings == null || alltrue([
+      for endpoint in [var.proxy_agent_settings.imds, var.proxy_agent_settings.wire_server] :
+      endpoint == null || endpoint.in_vm_access_control_profile_reference_id == null || can(regex(
+        "(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Compute/galleries/[^/]+/inVMAccessControlProfiles/[^/]+/versions/[^/]+$",
+        endpoint.in_vm_access_control_profile_reference_id
+      ))
+    ])
+    error_message = "A proxy agent access-control profile reference must be a valid Microsoft.Compute/galleries/inVMAccessControlProfiles/versions resource ID."
+  }
+  validation {
+    condition = (
+      var.proxy_agent_settings == null ||
+      var.proxy_agent_settings.add_proxy_agent_extension != true ||
+      try(var.os_profile.linux_configuration, null) != null
+    )
+    error_message = "`proxy_agent_settings.add_proxy_agent_extension = true` is only valid for a Linux VMSS."
+  }
+}
+
 variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string


### PR DESCRIPTION
## Description

Adds support for the Metadata Security Protocol (MSP) feature for the Guest Proxy Agent via a new `proxy_agent_settings` variable. MSP restricts in-guest access to the Azure Instance Metadata Service (IMDS) and WireServer, with per-endpoint `Audit`/`Enforce`/`Disabled` modes (or an InVMAccessControlProfile reference). Includes variable validation, `main.tf` wiring for the `azapi_resource`, README documentation, and unit tests.

Closes #213

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
