### PR TITLE
feat: expose ignore_body_changes per TFFR8

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.12)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -368,6 +368,34 @@ Description: (Optional) Specifies the time alloted for all extensions to start. 
 Type: `string`
 
 Default: `"PT1H30M"`
+
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: (Optional) Paths in each resource's `body` whose changes the `azapi` provider ignores after creation, letting an out-of-band controller own those properties without producing perpetual `terraform plan` drift. Prefer Terraform's `lifecycle.ignore_changes` when the paths are static; use this variable when the paths must be derived from variables or other non-static values.
+
+Keys follow the same naming rule as an AzAPI `resource_types` map (the snake\_case ARM resource type with the `Microsoft.` prefix dropped), scoped per resource:
+
+- `compute_virtual_machine_scale_sets` - Ignored body paths for the scale set managed by this module.
+- `authorization_locks` - Ignored body paths for the management lock created when `lock` is set.
+- `authorization_role_assignments` - Ignored body paths applied to every role assignment created from `role_assignments`.
+
+Paths use dot notation, for example `properties.virtualMachineProfile.priority` or the top-level `tags`. Individual list items cannot be targeted; ignore the whole list property instead. While a path is ignored, configuration changes at that path are **not** sent to Azure until the path is removed from the list.
+
+Ignore the whole property that an out-of-band controller owns rather than a nested key beneath it. Paths are matched against the properties present in your configuration, so a key that exists only in Azure is never compared and naming it has no effect.
+
+Supplying a **non-empty** value requires Terraform 1.11 or later, because `ignore_body_changes` is a write-only argument held in provider-private state; changes take effect only after an `apply`. Leaving every list empty (the default) emits no argument, so the module remains usable on earlier Terraform versions.
+
+Type:
+
+```hcl
+object({
+    compute_virtual_machine_scale_sets = optional(list(string), [])
+    authorization_locks                = optional(list(string), [])
+    authorization_role_assignments     = optional(list(string), [])
+  })
+```
+
+Default: `{}`
 
 ### <a name="input_instances"></a> [instances](#input\_instances)
 

--- a/main.tf
+++ b/main.tf
@@ -584,8 +584,11 @@ resource "azapi_resource" "virtual_machine_scale_set" {
       }
     } : {}
   )
-  create_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  # ignore_body_changes is a write-only argument; collapse an empty list to null so it is
+  # absent unless the consumer opts in, keeping the module usable before Terraform 1.11.
+  ignore_body_changes  = length(var.ignore_body_changes.compute_virtual_machine_scale_sets) > 0 ? var.ignore_body_changes.compute_virtual_machine_scale_sets : null
   ignore_null_property = true
   read_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   # Force recreation when zones are removed
@@ -643,11 +646,8 @@ resource "azapi_resource" "virtual_machine_scale_set" {
       "properties.virtualMachineProfile.extensionProfile.extensions[?name=='${ext_name}'].properties.protectedSettings" => version
     } : {}
   )
-  tags = var.tags
-  # ignore_body_changes is a write-only argument; collapse an empty list to null so it is
-  # absent unless the consumer opts in, keeping the module usable before Terraform 1.11.
-  ignore_body_changes = length(var.ignore_body_changes.compute_virtual_machine_scale_sets) > 0 ? var.ignore_body_changes.compute_virtual_machine_scale_sets : null
-  update_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  tags           = var.tags
+  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   # Managed identity configuration - must be at resource level, not in body
   dynamic "identity" {

--- a/main.tf
+++ b/main.tf
@@ -643,8 +643,11 @@ resource "azapi_resource" "virtual_machine_scale_set" {
       "properties.virtualMachineProfile.extensionProfile.extensions[?name=='${ext_name}'].properties.protectedSettings" => version
     } : {}
   )
-  tags           = var.tags
-  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  tags = var.tags
+  # ignore_body_changes is a write-only argument; collapse an empty list to null so it is
+  # absent unless the consumer opts in, keeping the module usable before Terraform 1.11.
+  ignore_body_changes = length(var.ignore_body_changes.compute_virtual_machine_scale_sets) > 0 ? var.ignore_body_changes.compute_virtual_machine_scale_sets : null
+  update_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   # Managed identity configuration - must be at resource level, not in body
   dynamic "identity" {
@@ -932,14 +935,15 @@ moved {
 resource "azapi_resource" "lock" {
   count = var.lock != null ? 1 : 0
 
-  name           = module.avm_utl_interfaces.lock_azapi.name != null ? module.avm_utl_interfaces.lock_azapi.name : "lock-${azapi_resource.virtual_machine_scale_set.name}"
-  parent_id      = azapi_resource.virtual_machine_scale_set.id
-  type           = module.avm_utl_interfaces.lock_azapi.type
-  body           = module.avm_utl_interfaces.lock_azapi.body
-  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  name                = module.avm_utl_interfaces.lock_azapi.name != null ? module.avm_utl_interfaces.lock_azapi.name : "lock-${azapi_resource.virtual_machine_scale_set.name}"
+  parent_id           = azapi_resource.virtual_machine_scale_set.id
+  type                = module.avm_utl_interfaces.lock_azapi.type
+  body                = module.avm_utl_interfaces.lock_azapi.body
+  create_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
+  read_headers        = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  update_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   depends_on = [azapi_resource.role_assignments]
 }
@@ -968,6 +972,7 @@ resource "azapi_resource" "role_assignments" {
   }
   create_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes  = length(var.ignore_body_changes.authorization_role_assignments) > 0 ? var.ignore_body_changes.authorization_role_assignments : null
   ignore_null_property = true
   read_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   retry = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.12"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/tests/unit/ignore_body_changes.tftest.hcl
+++ b/tests/unit/ignore_body_changes.tftest.hcl
@@ -1,0 +1,145 @@
+// ignore_body_changes is a write-only argument, so the provider holds it in private state and it
+// is never readable from an assertion. These runs therefore cover what is observable from the
+// module: that every documented key resolves, that a non-empty list is accepted on each of the
+// three azapi_resource blocks, and that the default empty object still plans and applies.
+mock_provider "azapi" {
+  mock_data "azapi_resource" {
+    defaults = {
+      exists = false
+      output = null
+    }
+  }
+
+  // The interfaces module resolves a role name to a role definition ID through this data source.
+  mock_data "azapi_resource_list" {
+    defaults = {
+      output = {
+        results = [{
+          id        = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+          role_name = "Contributor"
+        }]
+      }
+    }
+  }
+
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-ibc"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  extension_protected_setting = {}
+  location                    = "eastus"
+  name                        = "vmss-ibc"
+  parent_id                   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  admin_password              = "AvmUnitTest123!"
+  admin_password_version      = "1"
+  automatic_instance_repair   = null
+  custom_data                 = base64encode("ibc-test")
+  custom_data_version         = "1"
+  user_data_base64            = base64encode("ibc-test")
+  user_data_base64_version    = "1"
+  network_interface = [{
+    name    = "nic"
+    primary = true
+    ip_configuration = [{
+      name      = "ipconfig"
+      primary   = true
+      subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+    }]
+  }]
+  os_profile = {
+    windows_configuration = {
+      admin_username = "azureuser"
+      patch_mode     = "AutomaticByOS"
+    }
+  }
+  sku_name = "Standard_D2s_v5"
+  source_image_reference = {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-datacenter-g2"
+    version   = "latest"
+  }
+  tags = {
+    environment = "test"
+  }
+}
+
+run "default_is_an_empty_object" {
+  command = apply
+
+  assert {
+    condition     = length(var.ignore_body_changes.compute_virtual_machine_scale_sets) == 0
+    error_message = "The scale set slot must default to an empty list so the write-only argument is omitted."
+  }
+  assert {
+    condition     = length(var.ignore_body_changes.authorization_locks) == 0
+    error_message = "The lock slot must default to an empty list."
+  }
+  assert {
+    condition     = length(var.ignore_body_changes.authorization_role_assignments) == 0
+    error_message = "The role assignment slot must default to an empty list."
+  }
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.tags.environment == "test"
+    error_message = "Tags must still be sent when no body paths are ignored."
+  }
+}
+
+run "a_path_can_be_ignored_on_the_scale_set" {
+  command = apply
+
+  variables {
+    ignore_body_changes = {
+      compute_virtual_machine_scale_sets = ["tags"]
+    }
+  }
+
+  assert {
+    condition     = length(var.ignore_body_changes.compute_virtual_machine_scale_sets) == 1 && var.ignore_body_changes.compute_virtual_machine_scale_sets[0] == "tags"
+    error_message = "The scale set slot must accept a top-level body path."
+  }
+  assert {
+    condition     = length(var.ignore_body_changes.authorization_locks) == 0
+    error_message = "Setting the scale set slot must not populate the other slots."
+  }
+}
+
+run "every_slot_accepts_paths" {
+  command = apply
+
+  variables {
+    lock = {
+      kind = "CanNotDelete"
+    }
+    role_assignments = {
+      contributor = {
+        role_definition_id_or_name = "Contributor"
+        principal_id               = "00000000-0000-0000-0000-000000000001"
+      }
+    }
+    ignore_body_changes = {
+      compute_virtual_machine_scale_sets = ["tags", "properties.virtualMachineProfile.priority"]
+      authorization_locks                = ["properties.notes"]
+      authorization_role_assignments     = ["properties.description"]
+    }
+  }
+
+  assert {
+    condition     = length(var.ignore_body_changes.compute_virtual_machine_scale_sets) == 2
+    error_message = "The scale set slot must accept multiple dot-notation paths."
+  }
+  assert {
+    condition     = length(var.ignore_body_changes.authorization_locks) == 1 && var.ignore_body_changes.authorization_locks[0] == "properties.notes"
+    error_message = "The lock slot must be applied to the management lock resource."
+  }
+  assert {
+    condition     = length(var.ignore_body_changes.authorization_role_assignments) == 1 && var.ignore_body_changes.authorization_role_assignments[0] == "properties.description"
+    error_message = "The role assignment slot must be applied to the role assignment resources."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -370,6 +370,31 @@ variable "extensions_time_budget" {
   description = "(Optional) Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. Defaults to `PT1H30M`."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    compute_virtual_machine_scale_sets = optional(list(string), [])
+    authorization_locks                = optional(list(string), [])
+    authorization_role_assignments     = optional(list(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+(Optional) Paths in each resource's `body` whose changes the `azapi` provider ignores after creation, letting an out-of-band controller own those properties without producing perpetual `terraform plan` drift. Prefer Terraform's `lifecycle.ignore_changes` when the paths are static; use this variable when the paths must be derived from variables or other non-static values.
+
+Keys follow the same naming rule as an AzAPI `resource_types` map (the snake_case ARM resource type with the `Microsoft.` prefix dropped), scoped per resource:
+
+- `compute_virtual_machine_scale_sets` - Ignored body paths for the scale set managed by this module.
+- `authorization_locks` - Ignored body paths for the management lock created when `lock` is set.
+- `authorization_role_assignments` - Ignored body paths applied to every role assignment created from `role_assignments`.
+
+Paths use dot notation, for example `properties.virtualMachineProfile.priority` or the top-level `tags`. Individual list items cannot be targeted; ignore the whole list property instead. While a path is ignored, configuration changes at that path are **not** sent to Azure until the path is removed from the list.
+
+Ignore the whole property that an out-of-band controller owns rather than a nested key beneath it. Paths are matched against the properties present in your configuration, so a key that exists only in Azure is never compared and naming it has no effect.
+
+Supplying a **non-empty** value requires Terraform 1.11 or later, because `ignore_body_changes` is a write-only argument held in provider-private state; changes take effect only after an `apply`. Leaving every list empty (the default) emits no argument, so the module remains usable on earlier Terraform versions.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "instances" {
   type        = number
   default     = null


### PR DESCRIPTION
## Description

Implements [TFFR8 — AzAPI `ignore_body_changes` variable](https://azure.github.io/Azure-Verified-Modules/spec/TFFR8), which requires the `ignore_body_changes` argument of every `azapi_resource` to be consumer-configurable. Authors **MUST NOT** hard-code an inline list and **MUST NOT** omit the argument, because `lifecycle.ignore_changes` cannot be applied to a resource from outside the module that declares it.

`ignore_body_changes` lets a consumer suppress plan diffs for body paths that are mutated outside Terraform — for example a property owned by an autoscaler or applied by Azure Policy. It is the supported fallback for `lifecycle.ignore_changes` when the paths must come from variables or other non-static values, which `lifecycle` blocks cannot accept.

This PR implements the spec generically. No module-level defaults are shipped, and no specific out-of-band scenario is encoded — every slot defaults to an empty list.

```hcl
module "vmss" {
  source  = "Azure/avm-res-compute-virtualmachinescaleset/azurerm"
  version = "0.11.0"

  ignore_body_changes = {
    compute_virtual_machine_scale_sets = ["properties.virtualMachineProfile.priority"]
  }

  # ...other arguments...
}
```

### Slots

One slot per `azapi_resource` the module declares, keyed per [TFFR6](https://azure.github.io/Azure-Verified-Modules/spec/TFFR6) — snake_case ARM type, `Microsoft.` dropped, provider namespace as the leading token:

| Key | Resource | ARM type |
|---|---|---|
| `compute_virtual_machine_scale_sets` | `azapi_resource.virtual_machine_scale_set` | `Microsoft.Compute/virtualMachineScaleSets` |
| `authorization_locks` | `azapi_resource.lock` | `Microsoft.Authorization/locks` |
| `authorization_role_assignments` | `azapi_resource.role_assignments` | `Microsoft.Authorization/roleAssignments` |

The last two keys appear verbatim in TFFR6's own naming table. `azapi_update_resource.this` is excluded because the provider does not expose `ignore_body_changes` on that resource type.

Each assignment collapses an empty list to `null` so the write-only argument is absent unless the consumer opts in:

```terraform
ignore_body_changes = length(var.ignore_body_changes.compute_virtual_machine_scale_sets) > 0 ? var.ignore_body_changes.compute_virtual_machine_scale_sets : null
```

### Provider and Terraform versions

The `azapi` constraint moves from `~> 2.4` to `~> 2.12`, the release that introduced the argument. The Terraform `required_version` floor is deliberately left at `>= 1.9` per TFNFR25 — only a consumer supplying a **non-empty** list needs Terraform 1.11, and the default empty object emits no argument at all.

## Testing

- `terraform fmt -check -recursive` clean.
- `terraform validate` passes against azapi v2.12.0.
- `terraform test -test-directory=tests/unit` — **31 passed, 0 failed** (was 29).
- New `tests/unit/ignore_body_changes.tftest.hcl` covers the default empty object, a single path on the scale set slot, and all three slots populated together with `lock` and `role_assignments` actually created.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
