### PR TITLE
fix: only send constrainedMaximumCapacity when it is true

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -150,6 +150,23 @@ locals {
   })) : null
 }
 
+# Constrained maximum capacity preservation
+# Azure only accepts constrainedMaximumCapacity when it is true; the property must be
+# omitted entirely otherwise. Reading it back from an existing scale set and echoing the
+# false (or absent) value into the request body makes the API reject the write with
+# "InvalidParameter: Parameter 'constrainedMaximumCapacity' is not allowed".
+locals {
+  # Emit true only when the deployed scale set already has the property enabled, so the
+  # value set out-of-band is preserved. Anything else resolves to null, which
+  # ignore_null_property drops from the request body.
+  constrained_maximum_capacity = local.existing_constrained_maximum_capacity == true ? true : null
+  # Get existing constrainedMaximumCapacity value from the deployed resource
+  existing_constrained_maximum_capacity = data.azapi_resource.existing_vmss.exists ? try(
+    data.azapi_resource.existing_vmss.output.properties.constrainedMaximumCapacity,
+    null
+  ) : null
+}
+
 # License type normalization
 # The azurerm provider converts empty string to "None" during updates
 # This mimics that behavior to prevent drift

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "azapi_resource" "virtual_machine_scale_set" {
           highSpeedInterconnectPlacement = "None"
           orchestrationMode              = "Flexible"
           singlePlacementGroup           = false
-          constrainedMaximumCapacity     = data.azapi_resource.existing_vmss.exists ? data.azapi_resource.existing_vmss.output.properties.constrainedMaximumCapacity : null
+          constrainedMaximumCapacity     = local.constrained_maximum_capacity
         },
         {
           platformFaultDomainCount = var.platform_fault_domain_count

--- a/tests/unit/constrained_maximum_capacity.tftest.hcl
+++ b/tests/unit/constrained_maximum_capacity.tftest.hcl
@@ -1,0 +1,127 @@
+mock_provider "azapi" {
+  mock_data "azapi_resource" {
+    defaults = {
+      exists = false
+      output = null
+    }
+  }
+
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachineScaleSets/vmsscmc"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location                    = "qatarcentral"
+  name                        = "vmsscmc"
+  parent_id                   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+  admin_password              = "AvmUnitTest123!"
+  admin_password_version      = "1"
+  automatic_instance_repair   = null
+  custom_data                 = base64encode("cmc-test")
+  custom_data_version         = "1"
+  encryption_at_host_enabled  = true
+  extension_protected_setting = {}
+  user_data_base64            = base64encode("cmc-test")
+  user_data_base64_version    = "1"
+  network_interface = [{
+    name    = "nic"
+    primary = true
+    ip_configuration = [{
+      name      = "ipconfig"
+      primary   = true
+      subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+    }]
+  }]
+  os_profile = {
+    windows_configuration = {
+      admin_username = "azureuser"
+      patch_mode     = "AutomaticByOS"
+    }
+  }
+  sku_name = "Standard_D2s_v5"
+  source_image_reference = {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-datacenter-g2"
+    version   = "latest"
+  }
+}
+
+# Azure rejects the request with "InvalidParameter: Parameter
+# 'constrainedMaximumCapacity' is not allowed" unless the property is true or omitted.
+run "omitted_when_the_scale_set_does_not_exist" {
+  command = apply
+
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.constrainedMaximumCapacity == null
+    error_message = "'constrainedMaximumCapacity' must resolve to null on create so it is dropped from the Compute API request."
+  }
+}
+
+run "omitted_when_the_existing_scale_set_reports_false" {
+  command = apply
+
+  override_data {
+    target = data.azapi_resource.existing_vmss
+    values = {
+      exists = true
+      output = {
+        properties = {
+          constrainedMaximumCapacity = false
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.constrainedMaximumCapacity == null
+    error_message = "A false 'constrainedMaximumCapacity' read from the deployed scale set must not be echoed back to the Compute API."
+  }
+}
+
+run "omitted_when_the_existing_scale_set_does_not_report_the_property" {
+  command = apply
+
+  override_data {
+    target = data.azapi_resource.existing_vmss
+    values = {
+      exists = true
+      output = {
+        properties = {
+          singlePlacementGroup = false
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.constrainedMaximumCapacity == null
+    error_message = "An absent 'constrainedMaximumCapacity' in the read response must resolve to null rather than fail."
+  }
+}
+
+run "preserved_when_the_existing_scale_set_reports_true" {
+  command = apply
+
+  override_data {
+    target = data.azapi_resource.existing_vmss
+    values = {
+      exists = true
+      output = {
+        properties = {
+          constrainedMaximumCapacity = true
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.virtual_machine_scale_set.body.properties.constrainedMaximumCapacity == true
+    error_message = "A true 'constrainedMaximumCapacity' must be preserved so an out-of-band opt-in is not reset."
+  }
+}


### PR DESCRIPTION
## Description

Fixes #225.

`main.tf` echoed `constrainedMaximumCapacity` straight back from the resource read by `data.azapi_resource.existing_vmss`:

```hcl
constrainedMaximumCapacity = data.azapi_resource.existing_vmss.exists ? data.azapi_resource.existing_vmss.output.properties.constrainedMaximumCapacity : null
```

The ARM contract for the property ([`ComputeRP.json` @ `2025-04-01`](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2025-04-01/ComputeRP.json)) is:

> `constrainedMaximumCapacity` — *Optional property which must either be set to True or omitted.*

So `false` is not a legal value to write. Once a scale set exists and reports `false`, every subsequent apply sent `false` and Azure rejected the request:

```
RESPONSE 400: 400 Bad Request
ERROR CODE: InvalidParameter
{ "error": { "code": "InvalidParameter",
  "message": "Parameter 'constrainedMaximumCapacity' is not allowed.",
  "target": "constrainedMaximumCapacity" } }
```

This matches the reporter's "failing again and again" — the first apply creates the scale set, and every apply after that fails.

Note the create path was never affected: `ignore_null_property = true` is set on the scale set, and azapi's [`RemoveNullProperty`](https://github.com/Azure/terraform-provider-azapi/blob/main/utils/json.go) is recursive and runs before every PUT, so a `null` is dropped and never reaches Azure. Only the value read back from an existing scale set could reach the API.

### Second, latent bug

The read also lacked the `try()` guard used by the other `existing_vmss` lookups (`locals.tf:109`, `locals.tf:134`). A response that omits the property failed the plan outright with `Unsupported attribute` rather than falling back. The new tests cover this too.

## Fix

Emit `true` only when the deployed scale set already has it enabled, so an out-of-band opt-in is still preserved. Everything else resolves to `null`, which `ignore_null_property` drops from the request body.

```hcl
constrained_maximum_capacity = local.existing_constrained_maximum_capacity == true ? true : null
existing_constrained_maximum_capacity = data.azapi_resource.existing_vmss.exists ? try(
  data.azapi_resource.existing_vmss.output.properties.constrainedMaximumCapacity,
  null
) : null
```

The key is deliberately kept always-present in the body rather than added via a conditional `merge()`. A conditional merge on a value derived from `existing_vmss` would make the *key set* unknown whenever that read is deferred, turning the whole `properties` object unknown and reintroducing the destructive replacement fixed in #208 / #205.

## Testing

New `tests/unit/constrained_maximum_capacity.tftest.hcl` covers four cases:

| Case | Expected body value |
| --- | --- |
| scale set does not exist | `null` (omitted) |
| existing reports `false` | `null` (omitted) |
| existing omits the property | `null` (omitted, no crash) |
| existing reports `true` | `true` (preserved) |

Reverting the `locals.tf`/`main.tf` change fails two of them, confirming they are genuine regression tests:

```
run "omitted_when_the_existing_scale_set_reports_false"... fail
  --- actual
  +++ expected
  - false
  + null
run "omitted_when_the_existing_scale_set_does_not_report_the_property"... fail
  Error: Unsupported attribute
```

Full unit suite green with the fix applied:

```
Success! 32 passed, 0 failed.
```

`terraform validate` and `terraform fmt -recursive` are both clean. No variables or outputs changed, so no documentation regeneration is required.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
